### PR TITLE
(feat) add receipt cli param to generate a workflow.yaml

### DIFF
--- a/cmd/argo/commands/wait.go
+++ b/cmd/argo/commands/wait.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/ghodss/yaml"
 	"os"
 	"sync"
 
@@ -77,29 +76,6 @@ func waitOnOne(workflowName string, ignoreNotFound, quiet bool) {
 			if !quiet {
 				fmt.Printf("%s completed at %v\n", workflowName, wf.Status.FinishedAt)
 			}
-			var c = wfv1.Workflow{}
-			c.Kind = "Workflow"
-			c.APIVersion = "argoproj.io/v1alpha1"
-			c.SetGenerateName(wf.GetGenerateName())
-			c.SetNamespace(wf.GetNamespace())
-			c.Spec = *wf.Spec.DeepCopy()
-			for templateIdx, templateType := range wf.Spec.Templates {
-				if templateType.DAG == nil || templateType.DAG.Tasks == nil {
-					continue
-				}
-				for taskIdx, task := range templateType.DAG.Tasks {
-					for _, nodeStatus := range wf.Status.Nodes {
-						if nodeStatus.DisplayName == task.Name {
-							c.Spec.Templates[templateIdx].DAG.Tasks[taskIdx].Arguments.Artifacts = nodeStatus.Inputs.Artifacts
-							break
-						}
-					}
-
-				}
-			}
-			outBytes, _ := yaml.Marshal(c)
-			fmt.Print(string(outBytes))
-
 			return
 		}
 	}

--- a/cmd/argo/commands/wait.go
+++ b/cmd/argo/commands/wait.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/ghodss/yaml"
 	"os"
 	"sync"
 
@@ -76,6 +77,29 @@ func waitOnOne(workflowName string, ignoreNotFound, quiet bool) {
 			if !quiet {
 				fmt.Printf("%s completed at %v\n", workflowName, wf.Status.FinishedAt)
 			}
+			var c = wfv1.Workflow{}
+			c.Kind = "Workflow"
+			c.APIVersion = "argoproj.io/v1alpha1"
+			c.SetGenerateName(wf.GetGenerateName())
+			c.SetNamespace(wf.GetNamespace())
+			c.Spec = *wf.Spec.DeepCopy()
+			for templateIdx, templateType := range wf.Spec.Templates {
+				if templateType.DAG == nil || templateType.DAG.Tasks == nil {
+					continue
+				}
+				for taskIdx, task := range templateType.DAG.Tasks {
+					for _, nodeStatus := range wf.Status.Nodes {
+						if nodeStatus.DisplayName == task.Name {
+							c.Spec.Templates[templateIdx].DAG.Tasks[taskIdx].Arguments.Artifacts = nodeStatus.Inputs.Artifacts
+							break
+						}
+					}
+
+				}
+			}
+			outBytes, _ := yaml.Marshal(c)
+			fmt.Print(string(outBytes))
+
 			return
 		}
 	}


### PR DESCRIPTION
In  `argo submit` you can now provide a `--receipt` flag, which causes Argo to generate a `<workflow-name>.yaml` file in your workdirectory. This file represents the executed workflow and contains the calculated ipfs hashes, thus being a format for reproducible workflows.
